### PR TITLE
+ fix build permission issue

### DIFF
--- a/jenkins/jobs/ITRI_DISCO_os-brick.yaml
+++ b/jenkins/jobs/ITRI_DISCO_os-brick.yaml
@@ -17,6 +17,7 @@
 
           function pre_test_hook {{
               echo "Install thirdparty client libraries"
+              [ -e /home/jenkins/.ccache ] && sudo chown -R jenkins:jenkins /home/jenkins/.ccache
               #TODO: update your client here if needed, otherwise delete
               # sudo -H pip install mydriverclient
               echo "Configure the local.conf file to properly setup hp lefthand driver in cinder.conf"

--- a/jenkins/jobs/dsvm-cinder-driver.yaml
+++ b/jenkins/jobs/dsvm-cinder-driver.yaml
@@ -17,6 +17,7 @@
 
           function pre_test_hook {{
               echo "Install thirdparty client libraries"
+              sudo chown -R jenkins:jenkins /home/jenkins/.ccache
               #TODO: update your client here if needed, otherwise delete
               # sudo -H pip install mydriverclient
               echo "Configure the local.conf file to properly setup hp lefthand driver in cinder.conf"

--- a/jenkins/jobs/dsvm-cinder-driver.yaml
+++ b/jenkins/jobs/dsvm-cinder-driver.yaml
@@ -17,7 +17,7 @@
 
           function pre_test_hook {{
               echo "Install thirdparty client libraries"
-              sudo chown -R jenkins:jenkins /home/jenkins/.ccache
+              [ -e /home/jenkins/.ccache ] && sudo chown -R jenkins:jenkins /home/jenkins/.ccache
               #TODO: update your client here if needed, otherwise delete
               # sudo -H pip install mydriverclient
               echo "Configure the local.conf file to properly setup hp lefthand driver in cinder.conf"


### PR DESCRIPTION
> 19:21:36   x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include/python2.7 -c ext/_yaml.c -o build/temp.linux-x86_64-2.7/ext/_yaml.o
> 19:21:36   ccache: FATAL: Failed to create /home/jenkins/.ccache/e/6: Permission denied
> 19:21:36   error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
